### PR TITLE
chore: add missing fields to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
 	"name": "mismerge",
 	"type": "module",
 	"module": "esnext",
+	"license": "MIT",
+	"author": "BearToCode",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/BearToCode/mismerge.git"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,10 +2,12 @@
 	"name": "@mismerge/core",
 	"version": "0.0.1",
 	"description": "A modern merge editor for the Web",
+	"license": "MIT",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/BearToCode/mismerge.git"
 	},
+	"author": "BearToCode",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && npm run package",
@@ -57,5 +59,14 @@
 	"dependencies": {
 		"diff": "^5.1.0",
 		"nanoid": "^5.0.1"
-	}
+	},
+	"keywords": [
+		"editor",
+		"merge-editor",
+		"svelte",
+		"web-merge-editor",
+		"merge",
+		"mismerge",
+		"diff"
+	]
 }


### PR DESCRIPTION
add "license", "author" and "keywords" fields to published `package.json`.